### PR TITLE
Add DodgeBlocks Android game project

### DIFF
--- a/DodgeBlocks/README.md
+++ b/DodgeBlocks/README.md
@@ -1,0 +1,78 @@
+# Dodge Blocks (Android / Jetpack Compose)
+
+Juego Android completo listo para abrir en **Android Studio** y ejecutar en emulador/dispositivo.
+
+## Requisitos
+- Android Studio reciente (AGP **8.2.x** compatible).
+- SDK **34** instalado.
+- `minSdk 24`, `target/compileSdk 34`.
+- Java **17** (Android Studio ya lo gestiona por defecto).
+
+## Ejecutar (Android Studio)
+1. **Open** → selecciona la carpeta `DodgeBlocks/`.
+2. Espera a que termine **Gradle Sync**.
+3. Selecciona un emulador o dispositivo.
+4. **Run ▶ app**.
+
+> No usa red, no requiere claves, no necesita permisos extra (solo `VIBRATE`).
+
+## Controles
+- **En partida**: mueve el jugador (círculo) arrastrando el dedo (**drag**).
+- **Pausa**: botón de pausa (arriba a la derecha).
+- **Back**:
+  - Si estás jugando → pausa.
+  - Si estás en pausa o Game Over → vuelve al menú.
+
+## Pantallas
+### 1) Menú
+- Título del juego.
+- **High-score**.
+- **Top-5** de puntuaciones persistente.
+- Botones: **Jugar**, **Ajustes**.
+
+### 2) Juego
+- Canvas con jugador (círculo) y bloques (cuadrados) cayendo desde arriba.
+- Score = **tiempo sobrevivido en segundos redondeados**.
+- Pausa manual + **pausa automática** al ir la app a background.
+- Overlay de **Game Over** con **Reintentar** y **Menú**.
+- **Edge-to-edge inmersivo** (system bars ocultas; reaparecen temporalmente con swipe).
+- Pantalla encendida durante la partida (`FLAG_KEEP_SCREEN_ON`).
+
+### 3) Ajustes
+Persistentes vía **DataStore Preferences**:
+- `soundEnabled` (bool): sonido SOLO con efectos del sistema (`playSoundEffect`).
+- `vibrationEnabled` (bool): haptics al colisionar (`LocalHapticFeedback`).
+- `difficulty` (EASY/NORMAL/HARD): intervalo de spawn, tamaños, velocidades.
+- `skin` (CLASSIC/NEON/PASTEL): paletas jugador/bloques/fondo.
+- Toggle opcional **FPS overlay** (no persistente).
+
+## Features implementadas
+- Movimiento por drag.
+- Spawn de bloques con velocidad aleatoria.
+- **Colisión círculo vs rectángulo** correcta (closest-point + radio).
+- Dificultad progresiva: cada ~30s sube multiplicador de velocidad y aumenta ligeramente el spawn rate.
+- Leaderboard persistente: **Top-5** ordenado desc y **High-score**.
+- Haptics al colisionar (si está activado).
+- Sonido con efectos del sistema (sin `raw/`, sin binarios).
+- Portrait lock + edge-to-edge inmersivo + keep-screen-on + pausa por lifecycle.
+
+## Estructura del proyecto
+- `app/src/main/java/com/example/dodgeblocks/MainActivity.kt`  
+  UI Compose + navegación simple (Menu/Game/Settings) + loop y overlays.
+- `app/src/main/java/com/example/dodgeblocks/game/GameLogic.kt`  
+  Estado del mundo, loop, spawn, progresión de dificultad y colisiones.
+- `app/src/main/java/com/example/dodgeblocks/data/Prefs.kt`  
+  DataStore Preferences + leaderboard Top-5 (JSON) + high-score.
+- `app/src/main/java/com/example/dodgeblocks/data/PrefsCompose.kt`  
+  Helpers Compose (`rememberPrefs`, `rememberPrefsState`).
+- `app/src/main/java/com/example/dodgeblocks/ui/Theme.kt`  
+  Tema Material3.
+- `app/src/main/res/drawable/ic_launcher.xml`  
+  Icono vectorial simple (sin mipmap).
+- `app/src/main/AndroidManifest.xml`  
+  Solo permiso `VIBRATE`, orientación portrait.
+
+## Notas de compatibilidad
+- Sin dependencias de red.
+- Sin recursos binarios (sonido usa efectos del sistema).
+- Permisos mínimos: **solo** `VIBRATE`.

--- a/DodgeBlocks/app/build.gradle.kts
+++ b/DodgeBlocks/app/build.gradle.kts
@@ -1,0 +1,81 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.dodgeblocks"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.dodgeblocks"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += listOf(
+            "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
+        )
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        // Compatible con Kotlin 1.9.22 y BOM 2024.02.01
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+
+    packaging {
+        resources {
+            excludes += setOf(
+                "/META-INF/{AL2.0,LGPL2.1}"
+            )
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
+
+    implementation(platform("androidx.compose:compose-bom:2024.02.01"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/DodgeBlocks/app/proguard-rules.pro
+++ b/DodgeBlocks/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+# Reglas mínimas para apps Compose (mantener @Composable metadata no suele ser necesario,
+# pero esto evita problemas con reflection de tooling en builds optimizados).
+-keep class kotlin.Metadata { *; }
+
+# DataStore (Preferences) suele funcionar sin reglas extra; mantener por seguridad.
+-dontwarn kotlinx.coroutines.**
+-dontwarn androidx.datastore.**

--- a/DodgeBlocks/app/src/debug/AndroidManifest.xml
+++ b/DodgeBlocks/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        tools:node="merge"
+        tools:ignore="HardcodedDebugMode" />
+
+</manifest>

--- a/DodgeBlocks/app/src/main/AndroidManifest.xml
+++ b/DodgeBlocks/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@drawable/ic_launcher"
+        android:roundIcon="@drawable/ic_launcher"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.DodgeBlocks">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/MainActivity.kt
+++ b/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/MainActivity.kt
@@ -1,0 +1,772 @@
+package com.example.dodgeblocks
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.SoundEffectConstants
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.dodgeblocks.data.Difficulty
+import com.example.dodgeblocks.data.Prefs
+import com.example.dodgeblocks.data.Skin
+import com.example.dodgeblocks.data.rememberPrefs
+import com.example.dodgeblocks.data.rememberPrefsState
+import com.example.dodgeblocks.game.DifficultyParams
+import com.example.dodgeblocks.game.GameStatus
+import com.example.dodgeblocks.game.GameWorld
+import com.example.dodgeblocks.game.movePlayerBy
+import com.example.dodgeblocks.game.safeDt
+import com.example.dodgeblocks.game.setPaused
+import com.example.dodgeblocks.game.stepWorld
+import com.example.dodgeblocks.ui.DodgeBlocksTheme
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.max
+
+private sealed interface Screen {
+    data object Menu : Screen
+    data object Game : Screen
+    data object Settings : Screen
+}
+
+data class GamePalette(
+    val background: Color,
+    val player: Color,
+    val block: Color,
+    val hud: Color
+)
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableImmersiveEdgeToEdge()
+
+        setContent {
+            DodgeBlocksTheme {
+                val prefs = rememberPrefs()
+                val prefsState = rememberPrefsState(prefs)
+
+                var screen by rememberSaveable { mutableStateOf<Screen>(Screen.Menu) }
+                var gameSessionId by rememberSaveable { mutableIntStateOf(1) }
+                var showFps by rememberSaveable { mutableStateOf(false) }
+
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    when (screen) {
+                        Screen.Menu -> MenuScreen(
+                            highScore = prefsState.highScore,
+                            top5 = prefsState.top5,
+                            onPlay = {
+                                gameSessionId += 1
+                                screen = Screen.Game
+                            },
+                            onSettings = { screen = Screen.Settings }
+                        )
+
+                        Screen.Settings -> SettingsScreen(
+                            prefs = prefs,
+                            soundEnabled = prefsState.soundEnabled,
+                            vibrationEnabled = prefsState.vibrationEnabled,
+                            difficulty = prefsState.difficulty,
+                            skin = prefsState.skin,
+                            showFps = showFps,
+                            onShowFpsChange = { showFps = it },
+                            onBack = { screen = Screen.Menu }
+                        )
+
+                        Screen.Game -> GameScreen(
+                            prefs = prefs,
+                            difficulty = prefsState.difficulty,
+                            skin = prefsState.skin,
+                            soundEnabled = prefsState.soundEnabled,
+                            vibrationEnabled = prefsState.vibrationEnabled,
+                            showFps = showFps,
+                            gameSessionId = gameSessionId,
+                            onRetry = { gameSessionId += 1 },
+                            onMenu = { screen = Screen.Menu }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        enableImmersiveEdgeToEdge()
+    }
+
+    private fun enableImmersiveEdgeToEdge() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
+}
+
+@Composable
+private fun MenuScreen(
+    highScore: Int,
+    top5: List<Int>,
+    onPlay: () -> Unit,
+    onSettings: () -> Unit
+) {
+    val view = LocalView.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WindowInsets.safeDrawing.asPaddingValues())
+            .padding(20.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Dodge Blocks",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.ExtraBold
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = "High Score: $highScore",
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(Modifier.height(18.dp))
+        OutlinedCard(
+            modifier = Modifier.width(320.dp),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(Modifier.padding(14.dp)) {
+                Text(
+                    text = "Top 5",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(8.dp))
+                if (top5.isEmpty()) {
+                    Text(
+                        text = "Aún no hay puntuaciones. ¡Juega una partida!",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                } else {
+                    top5.take(5).forEachIndexed { i, s ->
+                        Row(
+                            Modifier.fillMaxSize(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(text = "${i + 1}.", fontWeight = FontWeight.SemiBold)
+                            Text(text = "$s s")
+                        }
+                        if (i != minOf(top5.size, 5) - 1) {
+                            Divider(Modifier.padding(vertical = 6.dp))
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(18.dp))
+
+        Button(
+            onClick = {
+                view.playSoundEffect(SoundEffectConstants.CLICK)
+                onPlay()
+            },
+            modifier = Modifier.width(240.dp)
+        ) {
+            Icon(Icons.Filled.PlayArrow, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Jugar")
+        }
+
+        Spacer(Modifier.height(10.dp))
+
+        FilledTonalButton(
+            onClick = {
+                view.playSoundEffect(SoundEffectConstants.CLICK)
+                onSettings()
+            },
+            modifier = Modifier.width(240.dp)
+        ) {
+            Icon(Icons.Filled.Settings, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Ajustes")
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsScreen(
+    prefs: Prefs,
+    soundEnabled: Boolean,
+    vibrationEnabled: Boolean,
+    difficulty: Difficulty,
+    skin: Skin,
+    showFps: Boolean,
+    onShowFpsChange: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    val view = LocalView.current
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WindowInsets.safeDrawing.asPaddingValues())
+            .padding(18.dp)
+    ) {
+        Text(
+            text = "Ajustes",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(Modifier.height(14.dp))
+
+        Card(shape = RoundedCornerShape(16.dp)) {
+            Column(Modifier.padding(14.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Sonido (efectos del sistema)",
+                        modifier = Modifier.weight(1f)
+                    )
+                    Switch(
+                        checked = soundEnabled,
+                        onCheckedChange = {
+                            view.playSoundEffect(SoundEffectConstants.CLICK)
+                            scope.launch { prefs.setSoundEnabled(it) }
+                        }
+                    )
+                }
+                Spacer(Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "Vibración / Haptics",
+                        modifier = Modifier.weight(1f)
+                    )
+                    Switch(
+                        checked = vibrationEnabled,
+                        onCheckedChange = {
+                            view.playSoundEffect(SoundEffectConstants.CLICK)
+                            scope.launch { prefs.setVibrationEnabled(it) }
+                        }
+                    )
+                }
+                Spacer(Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(text = "Mostrar FPS (overlay)", modifier = Modifier.weight(1f))
+                    Switch(checked = showFps, onCheckedChange = {
+                        view.playSoundEffect(SoundEffectConstants.CLICK)
+                        onShowFpsChange(it)
+                    })
+                }
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        var diffExpanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(
+            expanded = diffExpanded,
+            onExpandedChange = { diffExpanded = !diffExpanded }
+        ) {
+            OutlinedTextField(
+                value = difficulty.name,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Dificultad") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = diffExpanded) },
+                modifier = Modifier.menuAnchor().fillMaxSize()
+            )
+            ExposedDropdownMenu(
+                expanded = diffExpanded,
+                onDismissRequest = { diffExpanded = false }
+            ) {
+                Difficulty.values().forEach { d ->
+                    DropdownMenuItem(
+                        text = { Text(d.name) },
+                        onClick = {
+                            view.playSoundEffect(SoundEffectConstants.CLICK)
+                            diffExpanded = false
+                            scope.launch { prefs.setDifficulty(d) }
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        var skinExpanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(
+            expanded = skinExpanded,
+            onExpandedChange = { skinExpanded = !skinExpanded }
+        ) {
+            OutlinedTextField(
+                value = skin.name,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Skin") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = skinExpanded) },
+                modifier = Modifier.menuAnchor().fillMaxSize()
+            )
+            ExposedDropdownMenu(
+                expanded = skinExpanded,
+                onDismissRequest = { skinExpanded = false }
+            ) {
+                Skin.values().forEach { s ->
+                    DropdownMenuItem(
+                        text = { Text(s.name) },
+                        onClick = {
+                            view.playSoundEffect(SoundEffectConstants.CLICK)
+                            skinExpanded = false
+                            scope.launch { prefs.setSkin(s) }
+                        }
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(18.dp))
+        Text(
+            text = "Notas: sin red, sin recursos binarios. Sonido = efectos del sistema.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+        )
+
+        Spacer(Modifier.weight(1f))
+        Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxSize()) {
+            TextButton(onClick = {
+                view.playSoundEffect(SoundEffectConstants.CLICK)
+                onBack()
+            }) {
+                Text("Volver al Menú")
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameScreen(
+    prefs: Prefs,
+    difficulty: Difficulty,
+    skin: Skin,
+    soundEnabled: Boolean,
+    vibrationEnabled: Boolean,
+    showFps: Boolean,
+    gameSessionId: Int,
+    onRetry: () -> Unit,
+    onMenu: () -> Unit
+) {
+    val context = LocalContext.current
+    val activity = (context as? Activity)
+    val view = LocalView.current
+    val haptics = LocalHapticFeedback.current
+    val scope = rememberCoroutineScope()
+
+    DisposableEffect(gameSessionId) {
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    val palette = remember(skin) { paletteForSkin(skin) }
+    val params = remember(difficulty) {
+        paramsForDifficulty(difficulty, densityScale = view.resources.displayMetrics.density)
+    }
+
+    var viewport by remember { mutableStateOf(IntSize.Zero) }
+    var world by remember(gameSessionId) { mutableStateOf<GameWorld?>(null) }
+    var leaderboardSaved by remember(gameSessionId) { mutableStateOf(false) }
+
+    var fps by remember { mutableFloatStateOf(0f) }
+    var fpsAcc by remember { mutableFloatStateOf(0f) }
+    var fpsFrames by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(gameSessionId, viewport) {
+        if (viewport.width > 0 && viewport.height > 0) {
+            val seed = System.nanoTime() xor (gameSessionId.toLong() shl 17)
+            world = GameWorld.initial(
+                widthPx = viewport.width.toFloat(),
+                heightPx = viewport.height.toFloat(),
+                playerRadiusPx = 16f * view.resources.displayMetrics.density,
+                seed = seed
+            )
+        }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, gameSessionId) {
+        val obs = LifecycleEventObserver { _, event ->
+            val w = world ?: return@LifecycleEventObserver
+            if (event == Lifecycle.Event.ON_STOP || event == Lifecycle.Event.ON_PAUSE) {
+                if (w.status == GameStatus.RUNNING) {
+                    world = setPaused(w, paused = true)
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(obs)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+    }
+
+    LaunchedEffect(gameSessionId, viewport, params) {
+        var lastNanos = 0L
+        while (isActive) {
+            val frameNanos = androidx.compose.runtime.withFrameNanos { it }
+            if (lastNanos == 0L) {
+                lastNanos = frameNanos
+                continue
+            }
+            val w = world
+            if (w == null) {
+                lastNanos = frameNanos
+                continue
+            }
+
+            val dt = safeDt((frameNanos - lastNanos) / 1_000_000_000f)
+            lastNanos = frameNanos
+
+            if (showFps) {
+                fpsAcc += dt
+                fpsFrames += 1
+                if (fpsAcc >= 1.0f) {
+                    fps = (fpsFrames / max(0.001f, fpsAcc))
+                    fpsAcc = 0f
+                    fpsFrames = 0
+                }
+            } else {
+                fps = 0f
+                fpsAcc = 0f
+                fpsFrames = 0
+            }
+
+            if (w.status == GameStatus.RUNNING) {
+                val (next, collidedNow) = stepWorld(w, dt, params)
+
+                if (collidedNow && vibrationEnabled) {
+                    haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                }
+                if (collidedNow && soundEnabled) {
+                    view.playSoundEffect(SoundEffectConstants.NAVIGATION_DOWN)
+                }
+
+                world = next
+            }
+        }
+    }
+
+    LaunchedEffect(gameSessionId, world?.status) {
+        val w = world ?: return@LaunchedEffect
+        if (w.status == GameStatus.GAME_OVER && !leaderboardSaved) {
+            leaderboardSaved = true
+            prefs.updateLeaderboardIfNeeded(w.score)
+        }
+    }
+
+    BackHandler(enabled = true) {
+        val w = world
+        if (w == null) {
+            onMenu()
+            return@BackHandler
+        }
+        when (w.status) {
+            GameStatus.RUNNING -> world = setPaused(w, paused = true)
+            GameStatus.PAUSED, GameStatus.GAME_OVER -> onMenu()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(palette.background)
+            .padding(WindowInsets.safeDrawing.asPaddingValues())
+            .pointerInput(gameSessionId) {
+                detectDragGestures(
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        val w = world ?: return@detectDragGestures
+                        if (w.status == GameStatus.RUNNING) {
+                            world = movePlayerBy(w, dragAmount.x, dragAmount.y)
+                        }
+                    }
+                )
+            }
+    ) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .padding(8.dp)
+                .background(Color.Transparent)
+                .align(Alignment.Center)
+                .then(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(0.dp)
+                ),
+            onDraw = {
+                val size = IntSize(size.width.toInt(), size.height.toInt())
+                if (size != viewport) viewport = size
+
+                val w = world ?: return@Canvas
+
+                w.blocks.forEach { b ->
+                    drawRect(
+                        color = palette.block,
+                        topLeft = Offset(b.x, b.y),
+                        size = Size(b.size, b.size)
+                    )
+                }
+
+                drawCircle(
+                    color = palette.player,
+                    radius = w.player.r,
+                    center = Offset(w.player.x, w.player.y)
+                )
+            }
+        )
+
+        val w = world
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 10.dp, start = 12.dp, end = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedCard(
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.weight(1f)
+            ) {
+                Column(Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    Text(
+                        text = "Score: ${w?.score ?: 0}s",
+                        color = palette.hud,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    if (showFps) {
+                        Text(
+                            text = "FPS: ${fps.toInt()}",
+                            color = palette.hud.copy(alpha = 0.85f),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.width(10.dp))
+
+            IconButton(
+                onClick = {
+                    val ww = world ?: return@IconButton
+                    view.playSoundEffect(SoundEffectConstants.CLICK)
+                    world = setPaused(ww, paused = ww.status != GameStatus.PAUSED)
+                },
+                modifier = Modifier
+                    .size(52.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Pause,
+                    contentDescription = "Pausa",
+                    tint = palette.hud
+                )
+            }
+        }
+
+        if (w != null && w.status != GameStatus.RUNNING) {
+            OverlayCard(
+                title = if (w.status == GameStatus.PAUSED) "Pausado" else "Game Over",
+                subtitle = if (w.status == GameStatus.GAME_OVER) "Puntuación: ${w.score}s" else "Arrastra para esquivar los bloques",
+                primaryText = if (w.status == GameStatus.PAUSED) "Reanudar" else "Reintentar",
+                onPrimary = {
+                    if (soundEnabled) view.playSoundEffect(SoundEffectConstants.CLICK)
+                    if (w.status == GameStatus.PAUSED) {
+                        world = setPaused(w, paused = false)
+                    } else {
+                        onRetry()
+                    }
+                },
+                secondaryText = "Menú",
+                onSecondary = {
+                    if (soundEnabled) view.playSoundEffect(SoundEffectConstants.CLICK)
+                    onMenu()
+                },
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverlayCard(
+    title: String,
+    subtitle: String,
+    primaryText: String,
+    onPrimary: () -> Unit,
+    secondaryText: String,
+    onSecondary: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.42f))
+    ) {
+        Card(
+            modifier = modifier
+                .padding(18.dp),
+            shape = RoundedCornerShape(18.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Spacer(Modifier.height(14.dp))
+                Button(onClick = onPrimary, modifier = Modifier.width(220.dp)) {
+                    Text(primaryText)
+                }
+                Spacer(Modifier.height(8.dp))
+                FilledTonalButton(onClick = onSecondary, modifier = Modifier.width(220.dp)) {
+                    Text(secondaryText)
+                }
+            }
+        }
+    }
+}
+
+private fun paramsForDifficulty(d: Difficulty, densityScale: Float): DifficultyParams {
+    return when (d) {
+        Difficulty.EASY -> DifficultyParams(
+            baseSpawnIntervalSec = 0.85f,
+            blockSizePxMin = 34f * densityScale,
+            blockSizePxMax = 72f * densityScale,
+            speedPxPerSecMin = 240f * densityScale,
+            speedPxPerSecMax = 430f * densityScale
+        )
+
+        Difficulty.NORMAL -> DifficultyParams(
+            baseSpawnIntervalSec = 0.65f,
+            blockSizePxMin = 32f * densityScale,
+            blockSizePxMax = 78f * densityScale,
+            speedPxPerSecMin = 300f * densityScale,
+            speedPxPerSecMax = 520f * densityScale
+        )
+
+        Difficulty.HARD -> DifficultyParams(
+            baseSpawnIntervalSec = 0.48f,
+            blockSizePxMin = 28f * densityScale,
+            blockSizePxMax = 82f * densityScale,
+            speedPxPerSecMin = 360f * densityScale,
+            speedPxPerSecMax = 640f * densityScale
+        )
+    }
+}
+
+private fun paletteForSkin(s: Skin): GamePalette {
+    return when (s) {
+        Skin.CLASSIC -> GamePalette(
+            background = Color(0xFF0B1220),
+            player = Color(0xFF60A5FA),
+            block = Color(0xFFE2E8F0),
+            hud = Color(0xFFE2E8F0)
+        )
+
+        Skin.NEON -> GamePalette(
+            background = Color(0xFF070A12),
+            player = Color(0xFF22C55E),
+            block = Color(0xFFF97316),
+            hud = Color(0xFFE2E8F0)
+        )
+
+        Skin.PASTEL -> GamePalette(
+            background = Color(0xFFF8FAFC),
+            player = Color(0xFF93C5FD),
+            block = Color(0xFFFBCFE8),
+            hud = Color(0xFF0F172A)
+        )
+    }
+}

--- a/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/data/Prefs.kt
+++ b/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/data/Prefs.kt
@@ -1,0 +1,114 @@
+package com.example.dodgeblocks.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.json.JSONArray
+import kotlin.math.max
+
+enum class Difficulty { EASY, NORMAL, HARD }
+enum class Skin { CLASSIC, NEON, PASTEL }
+
+private val Context.dataStore by preferencesDataStore(name = "dodgeblocks_prefs")
+
+class Prefs(private val context: Context) {
+
+    private object Keys {
+        val soundEnabled = booleanPreferencesKey("soundEnabled")
+        val vibrationEnabled = booleanPreferencesKey("vibrationEnabled")
+        val difficulty = stringPreferencesKey("difficulty")
+        val skin = stringPreferencesKey("skin")
+        val highScore = intPreferencesKey("highScore")
+        val top5 = stringPreferencesKey("top5_json")
+    }
+
+    val soundEnabledFlow: Flow<Boolean> =
+        context.dataStore.data.map { it[Keys.soundEnabled] ?: true }
+
+    val vibrationEnabledFlow: Flow<Boolean> =
+        context.dataStore.data.map { it[Keys.vibrationEnabled] ?: true }
+
+    val difficultyFlow: Flow<Difficulty> =
+        context.dataStore.data.map { prefs ->
+            prefs[Keys.difficulty]?.let { runCatching { Difficulty.valueOf(it) }.getOrNull() }
+                ?: Difficulty.NORMAL
+        }
+
+    val skinFlow: Flow<Skin> =
+        context.dataStore.data.map { prefs ->
+            prefs[Keys.skin]?.let { runCatching { Skin.valueOf(it) }.getOrNull() } ?: Skin.CLASSIC
+        }
+
+    val highScoreFlow: Flow<Int> =
+        context.dataStore.data.map { it[Keys.highScore] ?: 0 }
+
+    val top5Flow: Flow<List<Int>> =
+        context.dataStore.data.map { prefs ->
+            decodeTop5(prefs[Keys.top5])
+        }
+
+    suspend fun setSoundEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.soundEnabled] = enabled }
+    }
+
+    suspend fun setVibrationEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.vibrationEnabled] = enabled }
+    }
+
+    suspend fun setDifficulty(difficulty: Difficulty) {
+        context.dataStore.edit { it[Keys.difficulty] = difficulty.name }
+    }
+
+    suspend fun setSkin(skin: Skin) {
+        context.dataStore.edit { it[Keys.skin] = skin.name }
+    }
+
+    /**
+     * Actualiza highScore y top-5 (orden desc, máx 5).
+     * Intención: llamada en Game Over si el score entra en ranking.
+     */
+    suspend fun updateLeaderboardIfNeeded(newScore: Int) {
+        if (newScore <= 0) return
+
+        context.dataStore.edit { prefs: Preferences ->
+            val currentTop = decodeTop5(prefs[Keys.top5]).toMutableList()
+            val currentHigh = prefs[Keys.highScore] ?: 0
+
+            // Insertar score y mantener top-5
+            currentTop.add(newScore)
+            currentTop.sortDescending()
+            val nextTop = currentTop.take(5)
+
+            val nextHigh = max(currentHigh, newScore)
+
+            // Guardar siempre top y high (simple y robusto)
+            prefs[Keys.top5] = encodeTop5(nextTop)
+            prefs[Keys.highScore] = nextHigh
+        }
+    }
+
+    private fun encodeTop5(list: List<Int>): String {
+        val arr = JSONArray()
+        list.forEach { arr.put(it) }
+        return arr.toString()
+    }
+
+    private fun decodeTop5(json: String?): List<Int> {
+        if (json.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val arr = JSONArray(json)
+            buildList {
+                for (i in 0 until arr.length()) {
+                    val v = arr.optInt(i, 0)
+                    if (v > 0) add(v)
+                }
+            }.sortedDescending().take(5)
+        }.getOrElse { emptyList() }
+    }
+}

--- a/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/data/PrefsCompose.kt
+++ b/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/data/PrefsCompose.kt
@@ -1,0 +1,42 @@
+package com.example.dodgeblocks.data
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.platform.LocalContext
+
+data class PrefsState(
+    val soundEnabled: Boolean,
+    val vibrationEnabled: Boolean,
+    val difficulty: Difficulty,
+    val skin: Skin,
+    val highScore: Int,
+    val top5: List<Int>
+)
+
+@Composable
+fun rememberPrefs(context: Context = LocalContext.current): Prefs {
+    // Intención: instancia única ligada al Contexto actual.
+    return remember(context) { Prefs(context.applicationContext) }
+}
+
+@Composable
+fun rememberPrefsState(prefs: Prefs): PrefsState {
+    val sound by prefs.soundEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+    val vib by prefs.vibrationEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+    val diff by prefs.difficultyFlow.collectAsStateWithLifecycle(initialValue = Difficulty.NORMAL)
+    val skin by prefs.skinFlow.collectAsStateWithLifecycle(initialValue = Skin.CLASSIC)
+    val high by prefs.highScoreFlow.collectAsStateWithLifecycle(initialValue = 0)
+    val top5 by prefs.top5Flow.collectAsStateWithLifecycle(initialValue = emptyList())
+
+    return PrefsState(
+        soundEnabled = sound,
+        vibrationEnabled = vib,
+        difficulty = diff,
+        skin = skin,
+        highScore = high,
+        top5 = top5
+    )
+}

--- a/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/game/GameLogic.kt
+++ b/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/game/GameLogic.kt
@@ -1,0 +1,212 @@
+package com.example.dodgeblocks.game
+
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+enum class GameStatus { RUNNING, PAUSED, GAME_OVER }
+
+data class Player(
+    val x: Float,
+    val y: Float,
+    val r: Float
+)
+
+data class Block(
+    val x: Float,
+    val y: Float,
+    val size: Float,
+    val vy: Float
+)
+
+data class DifficultyParams(
+    val baseSpawnIntervalSec: Float,
+    val blockSizePxMin: Float,
+    val blockSizePxMax: Float,
+    val speedPxPerSecMin: Float,
+    val speedPxPerSecMax: Float
+)
+
+data class Rng(val state: Long) {
+    // LCG simple: determinista, sin dependencias externas.
+    fun next(): Rng = Rng(state * 6364136223846793005L + 1442695040888963407L)
+
+    fun nextFloat01(): Pair<Float, Rng> {
+        val n = next()
+        // Tomar 24 bits altos para float [0,1)
+        val bits = ((n.state ushr 40) and 0xFFFFFF).toInt()
+        val f = bits / 16777216f
+        return f to n
+    }
+
+    fun nextFloat(min: Float, max: Float): Pair<Float, Rng> {
+        val (u, n) = nextFloat01()
+        return (min + (max - min) * u) to n
+    }
+
+    fun nextInt(min: Int, maxInclusive: Int): Pair<Int, Rng> {
+        val (u, n) = nextFloat01()
+        val v = min + (u * (maxInclusive - min + 1)).toInt().coerceIn(0, (maxInclusive - min))
+        return v to n
+    }
+}
+
+data class GameWorld(
+    val status: GameStatus,
+    val widthPx: Float,
+    val heightPx: Float,
+    val elapsedSec: Float,
+    val score: Int,
+    val player: Player,
+    val blocks: List<Block>,
+    val spawnAccumulatorSec: Float,
+    val rng: Rng
+) {
+    companion object {
+        fun initial(
+            widthPx: Float,
+            heightPx: Float,
+            playerRadiusPx: Float,
+            seed: Long
+        ): GameWorld {
+            val p = Player(
+                x = widthPx / 2f,
+                y = heightPx * 0.82f,
+                r = playerRadiusPx
+            )
+            return GameWorld(
+                status = GameStatus.RUNNING,
+                widthPx = widthPx,
+                heightPx = heightPx,
+                elapsedSec = 0f,
+                score = 0,
+                player = p,
+                blocks = emptyList(),
+                spawnAccumulatorSec = 0f,
+                rng = Rng(seed)
+            )
+        }
+    }
+}
+
+data class StepResult(
+    val world: GameWorld,
+    val collidedNow: Boolean
+)
+
+/**
+ * Paso de simulación:
+ * - dtSec viene limitado fuera a <= 0.033
+ * - dificultad progresiva: cada ~30s sube multiplicador de velocidad y ligeramente el spawn rate.
+ * - colisión círculo vs rectángulo (closest point) correcta.
+ */
+fun stepWorld(world: GameWorld, dtSec: Float, params: DifficultyParams): StepResult {
+    if (world.status != GameStatus.RUNNING) return StepResult(world, collidedNow = false)
+
+    val nextElapsed = world.elapsedSec + dtSec
+
+    // Progresión por "tiers" cada 30s
+    val tier = floor(nextElapsed / 30f).toInt().coerceAtLeast(0)
+    val speedMul = 1f + tier * 0.12f
+    val spawnMul = 1f + tier * 0.05f
+
+    val effectiveSpawnInterval = params.baseSpawnIntervalSec / spawnMul
+
+    var rng = world.rng
+    var acc = world.spawnAccumulatorSec + dtSec
+    val spawned = mutableListOf<Block>()
+
+    while (acc >= effectiveSpawnInterval) {
+        acc -= effectiveSpawnInterval
+
+        val (size, rng1) = rng.nextFloat(params.blockSizePxMin, params.blockSizePxMax)
+        rng = rng1
+
+        val maxX = max(0f, world.widthPx - size)
+        val (x, rng2) = rng.nextFloat(0f, maxX)
+        rng = rng2
+
+        val (vyBase, rng3) = rng.nextFloat(params.speedPxPerSecMin, params.speedPxPerSecMax)
+        rng = rng3
+
+        spawned += Block(
+            x = x,
+            y = -size,
+            size = size,
+            vy = vyBase * speedMul
+        )
+    }
+
+    // Mover bloques
+    val moved = (world.blocks + spawned).map { b ->
+        b.copy(y = b.y + b.vy * dtSec)
+    }.filter { b ->
+        // Mantener mientras pueda colisionar (un poco más abajo del borde)
+        b.y <= world.heightPx + b.size * 1.2f
+    }
+
+    // Actualizar score: segundos redondeados
+    val nextScore = nextElapsed.roundToInt().coerceAtLeast(0)
+
+    // Colisión
+    val collided = moved.any { b -> circleRectCollides(world.player, b) }
+
+    val nextWorld = if (collided) {
+        world.copy(
+            status = GameStatus.GAME_OVER,
+            elapsedSec = nextElapsed,
+            score = nextScore,
+            blocks = moved,
+            spawnAccumulatorSec = acc,
+            rng = rng
+        )
+    } else {
+        world.copy(
+            elapsedSec = nextElapsed,
+            score = nextScore,
+            blocks = moved,
+            spawnAccumulatorSec = acc,
+            rng = rng
+        )
+    }
+
+    return StepResult(nextWorld, collidedNow = collided)
+}
+
+fun movePlayerBy(world: GameWorld, dx: Float, dy: Float): GameWorld {
+    val p = world.player
+    val nx = (p.x + dx).coerceIn(p.r, world.widthPx - p.r)
+    val ny = (p.y + dy).coerceIn(p.r, world.heightPx - p.r)
+    return world.copy(player = p.copy(x = nx, y = ny))
+}
+
+fun setPaused(world: GameWorld, paused: Boolean): GameWorld {
+    val next = when {
+        world.status == GameStatus.GAME_OVER -> world.status
+        paused -> GameStatus.PAUSED
+        else -> GameStatus.RUNNING
+    }
+    return world.copy(status = next)
+}
+
+private fun circleRectCollides(c: Player, r: Block): Boolean {
+    // Rect: [x, x+size] x [y, y+size]
+    val closestX = clamp(c.x, r.x, r.x + r.size)
+    val closestY = clamp(c.y, r.y, r.y + r.size)
+    val dx = c.x - closestX
+    val dy = c.y - closestY
+    return (dx * dx + dy * dy) <= (c.r * c.r)
+}
+
+private fun clamp(v: Float, lo: Float, hi: Float): Float = min(hi, max(lo, v))
+
+/**
+ * Heurística para suavizar un "pico" de dt (por ejemplo al reanudar):
+ * limitar dt a 0.033 se hace fuera; aquí solo exponemos un helper si hiciera falta.
+ */
+fun safeDt(dtSec: Float): Float {
+    val absDt = abs(dtSec)
+    return absDt.coerceIn(0f, 0.033f)
+}

--- a/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/ui/Theme.kt
+++ b/DodgeBlocks/app/src/main/java/com/example/dodgeblocks/ui/Theme.kt
@@ -1,0 +1,42 @@
+package com.example.dodgeblocks.ui
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF2563EB),
+    onPrimary = Color.White,
+    secondary = Color(0xFF16A34A),
+    onSecondary = Color.White,
+    background = Color(0xFFF8FAFC),
+    onBackground = Color(0xFF0F172A),
+    surface = Color.White,
+    onSurface = Color(0xFF0F172A)
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFF60A5FA),
+    onPrimary = Color(0xFF0B1220),
+    secondary = Color(0xFF4ADE80),
+    onSecondary = Color(0xFF0B1220),
+    background = Color(0xFF0B1220),
+    onBackground = Color(0xFFE2E8F0),
+    surface = Color(0xFF0F172A),
+    onSurface = Color(0xFFE2E8F0)
+)
+
+@Composable
+fun DodgeBlocksTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColors else LightColors,
+        typography = androidx.compose.material3.Typography(),
+        content = content
+    )
+}

--- a/DodgeBlocks/app/src/main/res/drawable/ic_launcher.xml
+++ b/DodgeBlocks/app/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Fondo -->
+    <path
+        android:fillColor="#0B1220"
+        android:pathData="M0,0h108v108h-108z" />
+
+    <!-- Bloques cayendo -->
+    <path
+        android:fillColor="#E2E8F0"
+        android:pathData="M18,18h22v22h-22z" />
+    <path
+        android:fillColor="#F97316"
+        android:pathData="M64,22h18v18h-18z" />
+    <path
+        android:fillColor="#22C55E"
+        android:pathData="M78,54h16v16h-16z" />
+
+    <!-- Jugador (círculo) -->
+    <path
+        android:fillColor="#60A5FA"
+        android:pathData="M54,84
+                          m-16,0
+                          a16,16 0 1,0 32,0
+                          a16,16 0 1,0 -32,0" />
+</vector>

--- a/DodgeBlocks/app/src/main/res/values-night/themes.xml
+++ b/DodgeBlocks/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,6 @@
+<resources>
+    <style name="Theme.DodgeBlocks" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/DodgeBlocks/app/src/main/res/values/strings.xml
+++ b/DodgeBlocks/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Dodge Blocks</string>
+</resources>

--- a/DodgeBlocks/app/src/main/res/values/themes.xml
+++ b/DodgeBlocks/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources>
+    <!-- Tema base XML mínimo (Compose renderiza Material3 dentro).
+         Sin ActionBar para pantalla completa/edge-to-edge. -->
+    <style name="Theme.DodgeBlocks" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/DodgeBlocks/build.gradle.kts
+++ b/DodgeBlocks/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/DodgeBlocks/gradle.properties
+++ b/DodgeBlocks/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+kotlin.code.style=official

--- a/DodgeBlocks/settings.gradle.kts
+++ b/DodgeBlocks/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "DodgeBlocks"
+include(":app")

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ This repository is not currently linked to a public GitHub URL in this environme
 
 After pushing, that GitHub URL will host the full project, including the `DodgeBlocks/` Android game.
 
+## Android Studio (juego DodgeBlocks)
+
+El juego Android completo está en `DodgeBlocks/`. Para abrirlo en Android Studio:
+
+1. En Android Studio: **File → Open** y selecciona la carpeta `DodgeBlocks/`.
+2. Espera a que finalice **Gradle Sync**.
+3. Elige un emulador o dispositivo.
+4. Pulsa **Run ▶ app** para instalar y ejecutar.
+
+Requisitos rápidos: Android Studio reciente (AGP 8.2.x), Java 17, `compileSdk/targetSdk 34`, `minSdk 24` (todo ya configurado en el proyecto).
+
 ## Developing Locally
 
 | Prerequisites                                                                |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ All commands are run from the root of the project, from a terminal:
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/astro-platform-starter)
 
+## GitHub URL
+
+This repository is not currently linked to a public GitHub URL in this environment (no `origin` remote is configured). To push it to your own GitHub account:
+
+1. Create a new empty repository on GitHub (e.g., `https://github.com/<tu-usuario>/<tu-repo>`).
+2. Add it as a remote: `git remote add origin https://github.com/<tu-usuario>/<tu-repo>.git`.
+3. Push the current branch: `git push -u origin work` (or the branch name you prefer).
+
+After pushing, that GitHub URL will host the full project, including the `DodgeBlocks/` Android game.
+
 ## Developing Locally
 
 | Prerequisites                                                                |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ El juego Android completo está en `DodgeBlocks/`. Para abrirlo en Android Studi
 
 Requisitos rápidos: Android Studio reciente (AGP 8.2.x), Java 17, `compileSdk/targetSdk 34`, `minSdk 24` (todo ya configurado en el proyecto).
 
+### Clonar el repo directamente desde Android Studio
+
+Si prefieres clonar con la opción **Get from VCS** (pantalla con campo "Repository URL"):
+
+1. En Android Studio: **File → New → Project from Version Control…** (o el botón **Get from VCS** de la pantalla inicial).
+2. En **Version control** elige **Git** y pega la URL de tu repositorio (ej.: `https://github.com/<tu-usuario>/<tu-repo>.git`).
+3. Selecciona la carpeta de destino y pulsa **Clone**. Android Studio descargará el repo completo.
+4. Cuando termine, en el diálogo de importación elige abrir el subdirectorio `DodgeBlocks/` (es el proyecto Android). Si ya se abre la raíz, usa **File → Open…** y selecciona `DodgeBlocks/`.
+5. Deja que corra **Gradle Sync** y luego usa **Run ▶ app**.
+
 ## Developing Locally
 
 | Prerequisites                                                                |


### PR DESCRIPTION
### Motivation
- Provide a complete Android sample game built with Jetpack Compose that demonstrates game loop, input, and simple persistence.
- Include a small, self-contained gameplay implementation (player, falling blocks, collisions) suitable for opening in Android Studio.
- Persist user preferences and a simple Top-5 leaderboard using `DataStore` to demonstrate state persistence across runs.

### Description
- Add a new `DodgeBlocks` Gradle project with `settings.gradle.kts`, top-level `build.gradle.kts`, and `gradle.properties`, plus an `app` module configured for Compose in `app/build.gradle.kts`.
- Implement main UI and app flow in `MainActivity.kt` with screens for Menu, Game, and Settings, an in-UI game loop, touch drag input, FPS overlay, and lifecycle-aware pause behavior.
- Add game core in `game/GameLogic.kt` including deterministic LCG `Rng`, `GameWorld` state, `stepWorld` simulation, collision detection (`circleRectCollides`), and helper functions `safeDt`, `movePlayerBy`, and `setPaused`.
- Add preferences and persistence in `data/Prefs.kt` and `data/PrefsCompose.kt` using `DataStore` for `soundEnabled`, `vibrationEnabled`, `difficulty`, `skin`, `highScore`, and JSON-encoded `top5`, plus theme and resources in `ui/Theme.kt`, `res/drawable/ic_launcher.xml`, manifests, ProGuard rules, and `README.md` with usage notes.

### Testing
- No automated tests were executed as part of this change.
- Project build or runtime validation in Android Studio was not performed by the automation that created these files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac3eefba4832cb23fa5fa1d1903fd)